### PR TITLE
修复切换 skin 后样式名称不正确的问题

### DIFF
--- a/packages/mac-scrollbar/src/GlobalScrollbar.tsx
+++ b/packages/mac-scrollbar/src/GlobalScrollbar.tsx
@@ -13,11 +13,12 @@ export interface GlobalScrollbarProps extends GlobalScrollbarBase {
   trackGap?: number;
 }
 
-function GlobalScrollbarInject({ skin = 'white', ...props }: GlobalScrollbarProps) {
+function GlobalScrollbarInject({ skin = 'light', ...props }: GlobalScrollbarProps) {
   const wrapper = useInitial(() => document.createElement('div'));
 
   useEffect(() => {
     wrapper.classList.add('ms-track-global', `ms-theme-${skin}`);
+    wrapper.classList.remove(`ms-theme-${skin === 'light' ? 'dark' : 'light'}`);
     const wrapperCls = 'ms-container';
     const docClassList = document.documentElement.classList;
 

--- a/packages/mac-scrollbar/src/Scrollbar.less
+++ b/packages/mac-scrollbar/src/Scrollbar.less
@@ -24,7 +24,7 @@
   }
 }
 
-.ms-theme-white {
+.ms-theme-light {
   --ms-track-background: rgba(248, 248, 248, 0.76);
   --ms-track-border-color: #dfdfdf;
   --ms-thumb-color: rgba(0, 0, 0, 0.5);

--- a/packages/mac-scrollbar/src/Scrollbar.tsx
+++ b/packages/mac-scrollbar/src/Scrollbar.tsx
@@ -19,7 +19,7 @@ export default function ScrollBar({
   suppressScrollX,
   suppressScrollY,
   suppressAutoHide,
-  skin = 'white',
+  skin = 'light',
   trackGap,
   trackStyle,
   thumbStyle,

--- a/packages/mac-scrollbar/src/types.ts
+++ b/packages/mac-scrollbar/src/types.ts
@@ -33,9 +33,9 @@ export interface ActionPosition {
 export interface GlobalScrollbarBase {
   /**
    * Adapt to the background color of the container.
-   * @defaultValue 'white'
+   * @defaultValue 'light'
    */
-  skin?: 'white' | 'dark';
+  skin?: 'light' | 'dark';
   /**
    * Track style.
    */


### PR DESCRIPTION
修复切换 skin 后样式名称不正确的问题
修改属性 skin 的值为更通俗的名称