### PR TITLE
fix: ms-track position is affected by flex layout

### DIFF
--- a/packages/mac-scrollbar/src/MacScrollbar.less
+++ b/packages/mac-scrollbar/src/MacScrollbar.less
@@ -16,6 +16,7 @@
     position: sticky;
     top: 100%;
     left: 0;
+    width: 100%;
     z-index: @ms-z-index;
   }
 }


### PR DESCRIPTION
问题:
当在 `MacScrollbar` 上应用 `display:flex; flex-direction: column; align-items: center` 时，track部分会被错误地居中展示

复现:
![image](https://github.com/MinJieLiu/mac-scrollbar/assets/59609929/4fe0fbe8-e7ed-4494-bca6-210edf72b3ae)

竖直方向受影响
```
<MacScrollbar style={ {
  width: 200,
  height: 200,
  background: '#ccc',
  display: 'flex',
  flexDirection: 'column',
  alignItems: 'center',
  gap: '10px',
} }>
  {
    new Array(10).fill(0).map((_, index) => (
      <div key={`flow-y-${index}`} style={ { width: "fit-content", height: 20, background: '#aaa' } }>section { index }</div>
    ))
  }
</MacScrollbar>
```

由于 ms-track-box 设置了 `top: 100%` 置底，水平方向无影响
```
<MacScrollbar style={ {
  width: 200,
  height: 200,
  background: '#ccc',
  display: 'flex',
  flexDirection: 'row',
  alignItems: 'center',
  gap: '10px',
} }>
  {
    new Array(10).fill(0).map((_, index) => (
      <div key={`flow-x-${index}`} style={ { width: "fit-content", height: 20, background: '#aaa', flexShrink: 0 } }>section { index }</div>
    ))
  }
</MacScrollbar>
```